### PR TITLE
Switch to static piece arrays

### DIFF
--- a/src/book.c
+++ b/src/book.c
@@ -10,7 +10,7 @@ const struct Action* opening_move(const struct State* state)
 
     if (state->piece_count[P1] == 0 || state->piece_count[P2] == 0) {
         for (int i = 0; i < state->action_count; i++) {
-            switch (state->pieces[state->turn][state->actions[i].piecei].type) {
+            switch (state->pieces[state->turn][state->actions[i].from.r].type) {
             case BEETLE:
             case GRASSHOPPER:
             case SPIDER:

--- a/src/book.c
+++ b/src/book.c
@@ -10,7 +10,7 @@ const struct Action* opening_move(const struct State* state)
 
     if (state->piece_count[P1] == 0 || state->piece_count[P2] == 0) {
         for (int i = 0; i < state->action_count; i++) {
-            switch (state->actions[i].from.r) {
+            switch (state->pieces[state->turn][state->actions[i].piecei].type) {
             case BEETLE:
             case GRASSHOPPER:
             case SPIDER:

--- a/src/coords.c
+++ b/src/coords.c
@@ -105,6 +105,9 @@ bool Coords_map_adjacent(const struct Coords* coords, const struct Coords* other
 
 bool Coords_adjacent(const struct Coords* coords, const struct Coords* other)
 {
+    if (coords->q == IN_HAND || other->q == IN_HAND) {
+        return false;
+    }
     return Coords_map_adjacent(coords, other);
 }
 

--- a/src/simulate.c
+++ b/src/simulate.c
@@ -81,7 +81,7 @@ bool State_is_queen_sidestep(const struct State* state, const struct Action* act
     return state->neighbor_count[!state->turn][action->to.q][action->to.r] == 1
         && state->neighbor_count[state->turn][action->to.q][action->to.r] == 1
         // Not a sidestep if we're already in a similar position
-        && State_hex_neighbor_count(state, &state->pieces[state->turn][action->piecei].coords) > 1;
+        && State_hex_neighbor_count(state, &action->from) > 1;
 }
 
 /**
@@ -241,11 +241,9 @@ float State_simulate(struct State* state,
         Action_print(action, stderr);
 #endif
 
-        struct Coords *from = &state->pieces[state->turn][action->piecei].coords;
-
-        if (from->q != PLACE_ACTION
-            && action->piecei != PASS_ACTION
-            && Coords_adjacent(from, &state->pieces[!state->turn][QUEEN_INDEX].coords)
+        if (action->from.q != PLACE_ACTION
+            && action->from.q != PASS_ACTION
+            && Coords_adjacent(&action->from, &state->pieces[!state->turn][QUEEN_INDEX].coords)
             && (rand() / (float)RAND_MAX) < options->from_queen_pass) {
 #ifdef WATCH_SIMS
             printf("from queen pass\n");

--- a/src/state.h
+++ b/src/state.h
@@ -8,16 +8,22 @@
 
 #define NUM_PLAYERS 2
 
-#define PLAYER_PIECES 11
-#define MAX_PIECES (PLAYER_PIECES * NUM_PLAYERS)
-#define GRID_SIZE 24
-
 #define NUM_PIECETYPES 5
 #define NUM_ANTS 3
 #define NUM_BEETLES 2
 #define NUM_GRASSHOPPERS 3
 #define NUM_SPIDERS 2
 #define NUM_QUEEN_BEES 1
+
+#define PLAYER_PIECES (NUM_ANTS + NUM_BEETLES + NUM_GRASSHOPPERS + NUM_SPIDERS + NUM_QUEEN_BEES)
+#define MAX_PIECES (PLAYER_PIECES * NUM_PLAYERS)
+#define GRID_SIZE (MAX_PIECES + 2)
+
+#define ANT_INDEX 0
+#define BEETLE_INDEX (ANT_INDEX + NUM_ANTS)
+#define GRASSHOPPER_INDEX (BEETLE_INDEX + NUM_BEETLES)
+#define SPIDER_INDEX (GRASSHOPPER_INDEX + NUM_GRASSHOPPERS)
+#define QUEEN_INDEX (SPIDER_INDEX + NUM_SPIDERS)
 
 /* Way-high estimate for max actions:
  * An ant on the end of a line of all pieces (greatest surface area)
@@ -50,8 +56,11 @@
 // If Action.from.q == PLACE_ACTION, it means the action is a place, with
 // Action.r = PieceType
 #define PLACE_ACTION (GRID_SIZE + 1)
+// TODO IN_HAND will probably replace PLACE_ACTION
+#define IN_HAND (GRID_SIZE + 1)
+
 // TODO support passing when no moves are possible
-#define PASS_ACTION (GRID_SIZE + 2)
+#define PASS_ACTION (PLAYER_PIECES + 1)
 
 #define SPIDER_MOVES 3
 
@@ -59,6 +68,7 @@ enum Player {
     P1 = 0,
     P2
 };
+
 enum PieceType {
     ANT = 0,
     BEETLE,
@@ -66,6 +76,32 @@ enum PieceType {
     SPIDER,
     QUEEN_BEE
 };
+
+// Index for state.pieces
+const uint_fast8_t TYPE_INDEX[NUM_PIECETYPES] = {
+    ANT_INDEX,
+    BEETLE_INDEX,
+    GRASSHOPPER_INDEX,
+    SPIDER_INDEX,
+    QUEEN_INDEX
+};
+
+const uint_fast8_t TYPE_END[NUM_PIECETYPES] = {
+    ANT_INDEX + NUM_ANTS,
+    BEETLE_INDEX + NUM_BEETLES,
+    GRASSHOPPER_INDEX + NUM_GRASSHOPPERS,
+    SPIDER_INDEX + NUM_SPIDERS,
+    QUEEN_INDEX + NUM_QUEEN_BEES
+};
+
+const uint_fast8_t TYPE_COUNT[NUM_PIECETYPES] = {
+    NUM_ANTS,
+    NUM_BEETLES,
+    NUM_GRASSHOPPERS,
+    NUM_SPIDERS,
+    NUM_QUEEN_BEES
+};
+
 enum Result {
     P1_WIN = 0,
     P2_WIN,
@@ -74,7 +110,7 @@ enum Result {
 };
 
 struct Action {
-    struct Coords from;
+    uint_fast8_t piecei;
     struct Coords to;
 };
 
@@ -104,12 +140,8 @@ struct State {
 
     struct Action* winning_action;
 
-    struct Piece* queens[NUM_PLAYERS];
     struct Action* queen_moves[MAX_QUEEN_MOVES];
     uint_fast8_t queen_move_count;
-
-    struct Piece* beetles[NUM_PLAYERS][NUM_BEETLES];
-    uint_fast8_t beetle_count[NUM_PLAYERS];
 
     struct Action* piece_moves[PLAYER_PIECES][MAX_PIECE_MOVES];
     uint_fast16_t piece_move_count[PLAYER_PIECES];
@@ -153,10 +185,5 @@ void State_copy(const struct State* source, struct State* dest);
 void State_act(struct State* state, const struct Action* action);
 
 int State_hex_neighbor_count(const struct State* state, const struct Coords* coords);
-
-void State_count_cut_points(
-    const struct State* state,
-    const struct Coords* start_coords,
-    unsigned int cut_points[NUM_PLAYERS]);
 
 #endif

--- a/src/state.h
+++ b/src/state.h
@@ -60,7 +60,7 @@
 #define IN_HAND (GRID_SIZE + 1)
 
 // TODO support passing when no moves are possible
-#define PASS_ACTION (PLAYER_PIECES + 1)
+#define PASS_ACTION (GRID_SIZE + 2)
 
 #define SPIDER_MOVES 3
 
@@ -78,29 +78,11 @@ enum PieceType {
 };
 
 // Index for state.pieces
-const uint_fast8_t TYPE_INDEX[NUM_PIECETYPES] = {
-    ANT_INDEX,
-    BEETLE_INDEX,
-    GRASSHOPPER_INDEX,
-    SPIDER_INDEX,
-    QUEEN_INDEX
-};
+extern const uint_fast8_t TYPE_INDEX[NUM_PIECETYPES];
 
-const uint_fast8_t TYPE_END[NUM_PIECETYPES] = {
-    ANT_INDEX + NUM_ANTS,
-    BEETLE_INDEX + NUM_BEETLES,
-    GRASSHOPPER_INDEX + NUM_GRASSHOPPERS,
-    SPIDER_INDEX + NUM_SPIDERS,
-    QUEEN_INDEX + NUM_QUEEN_BEES
-};
+extern const uint_fast8_t TYPE_END[NUM_PIECETYPES];
 
-const uint_fast8_t TYPE_COUNT[NUM_PIECETYPES] = {
-    NUM_ANTS,
-    NUM_BEETLES,
-    NUM_GRASSHOPPERS,
-    NUM_SPIDERS,
-    NUM_QUEEN_BEES
-};
+extern const uint_fast8_t TYPE_COUNT[NUM_PIECETYPES];
 
 enum Result {
     P1_WIN = 0,
@@ -110,7 +92,7 @@ enum Result {
 };
 
 struct Action {
-    uint_fast8_t piecei;
+    struct Coords from;
     struct Coords to;
 };
 

--- a/src/test.c
+++ b/src/test.c
@@ -936,19 +936,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    // Queen cache
-    {
-        strcpy(state_string, "QbbabeAbfGcbgccqcd2");
-        State_from_string(&state, state_string);
-
-        if (!state.queens[P1] || state.queens[P1]->coords.q != 1 || state.queens[P1]->coords.r != 1) {
-            printf("Invalid queen cache for P1\n");
-        }
-        if (!state.queens[P2] || state.queens[P2]->coords.q != 2 || state.queens[P2]->coords.r != 3) {
-            printf("Invalid queen cache for P2\n");
-        }
-    }
-
     // Queen adjacent action tracking
     {
         strcpy(state_string, "gbeqbfbcdbdcGecAedQfb1");


### PR DESCRIPTION
Right now, the piece arrays on a State are stacks that start out empty and grow as pieces are added to the board. That means pieces will be in arbitrary orders, and if we need to know where (say) all the ants are, we either need to search through the entire array or cache references to ants elsewhere in State.

This branch changes State so that instead of growing as pieces are added to the board, the array starts full, and pieces are either on the board or in the hand (`piece.coords.q == IN_HAND`). This enables us to store pieces in the same order for every state, and easily look up specific pieces or pieces types.

(Branch is not ready to merge yet.)

Idea came from [Pieces](https://www.chessprogramming.org/Pieces#Piece_Coding) on the Chess Programming Wiki:

> Other programs distinguish not only piece-type and color, but enumerate all 32 pieces from their initial position, which label or code does not change during the course of a game (even after a possible promotion of a pawn) and might be one-to-one associated with the bit-position of a 32-bit piece set, and/or are used to index a piece list containing the current square the piece resides on. 