### PR TITLE
Fix compiler errors under clang.

### DIFF
--- a/src/book.c
+++ b/src/book.c
@@ -17,6 +17,7 @@ const struct Action* opening_move(const struct State* state)
                 actions[action_count++] = &state->actions[i];
                 break;
             default:
+                break;
             }
         }
     }

--- a/src/simulate.c
+++ b/src/simulate.c
@@ -121,7 +121,7 @@ float State_simulate(struct State* state,
             return 0.0;
         }
 
-    select_action:
+    select_action : {
 
         struct Action* action = NULL;
 
@@ -272,6 +272,7 @@ float State_simulate(struct State* state,
         printf("%s\n", state_string);
         getchar();
 #endif
+    }
     }
 
     stats->mean_sim_depth += (depth - stats->mean_sim_depth) / stats->simulations;

--- a/src/state.c
+++ b/src/state.c
@@ -85,6 +85,7 @@ void State_derive_grid(struct State* state)
 
             state->grid[piece->coords.q][piece->coords.r] = piece;
         skip:
+            continue;
         }
     }
 }
@@ -641,7 +642,7 @@ void State_derive_piece_moves(struct State* state, int piecei)
         State_ant_walk(state, piecei, piece, coords, crumbs);
         break;
 
-    case BEETLE:
+    case BEETLE: {
         bool on_top = state->grid[coords->q][coords->r] != piece;
 
         if (on_top) {
@@ -737,6 +738,7 @@ void State_derive_piece_moves(struct State* state, int piecei)
             }
         }
         break;
+    }
 
     case GRASSHOPPER:
         for (int d = 0; d < NUM_DIRECTIONS; d++) {

--- a/src/zoe.c
+++ b/src/zoe.c
@@ -163,7 +163,7 @@ int main(int argc, char* argv[])
         printf("%s\n", state_string);
         return 0;
 
-    case SEARCH:
+    case SEARCH: {
         struct MinimaxResults minimax_results;
         minimax(&state, &minimax_results, &minimax_options);
         fprintf(stderr, "action:\t");
@@ -172,8 +172,9 @@ int main(int argc, char* argv[])
         fprintf(stderr, "nodes:\t%ld\n", minimax_results.stats.nodes);
         fprintf(stderr, "leaves:\t%ld\n", minimax_results.stats.leaves);
         return 0;
+    }
 
-    case RANDOM:
+    case RANDOM: {
         struct Action* action = &state.actions[rand() % state.action_count];
 
         Action_to_string(action, action_string);
@@ -186,12 +187,14 @@ int main(int argc, char* argv[])
         State_to_string(&after, state_string);
         fprintf(stderr, "next:\t%s\n", state_string);
         return 0;
+    }
 
     case EXAMINE:
         State_examine(&state);
         return 0;
 
     case THINK:
+        break;
     }
 
     struct MCTSResults results;


### PR DESCRIPTION
Don't end a block with a label, and add a block around labels that define variables.